### PR TITLE
Collections exercise

### DIFF
--- a/projects/Cargo.toml
+++ b/projects/Cargo.toml
@@ -19,4 +19,5 @@ members = [
     "vector",
     "strings",
     "hashmaps",
+    "collections_exercise",
 ]

--- a/projects/collections_exercise/Cargo.toml
+++ b/projects/collections_exercise/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "collections_exercise"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/projects/collections_exercise/README.md
+++ b/projects/collections_exercise/README.md
@@ -1,0 +1,8 @@
+# Exercises at the end of the collections chapter
+Vectors, strings, and hash maps will provide a large amount of functionality necessary in programs when you need to store, access, and modify data. Here are some exercises you should now be equipped to solve:
+
+- Given a list of integers, use a vector and return the median (when sorted, the value in the middle position) and mode (the value that occurs most often; a hash map will be helpful here) of the list.
+- Convert strings to pig latin. The first consonant of each word is moved to the end of the word and “ay” is added, so “first” becomes “irst-fay.” Words that start with a vowel have “hay” added to the end instead (“apple” becomes “apple-hay”). Keep in mind the details about UTF-8 encoding!
+- Using a hash map and vectors, create a text interface to allow a user to add employee names to a department in a company. For example, “Add Sally to Engineering” or “Add Amir to Sales.” Then let the user retrieve a list of all people in a department or all people in the company by department, sorted alphabetically.
+
+The standard library API documentation describes methods that vectors, strings, and hash maps have that will be helpful for these exercises!

--- a/projects/collections_exercise/src/lib.rs
+++ b/projects/collections_exercise/src/lib.rs
@@ -1,0 +1,24 @@
+mod median_mode;
+#[cfg(test)]
+mod median_mode_tests {
+    use super::median_mode::median_mode;
+
+    #[test]
+    fn test_even_len() {
+        let arr = vec![3, 1, 2, 1];
+        let (median, mode) = median_mode(&arr);
+
+        assert_eq!(median, 1.5);
+        assert_eq!(mode, 1);
+    }
+
+    #[test]
+    fn test_odd_len() {
+        let arr = vec![3, 4, 2, 1, 3];
+        let (median, mode) = median_mode(&arr);
+
+        assert_eq!(median, 3.0);
+        assert_eq!(mode, 3);
+    }
+}
+

--- a/projects/collections_exercise/src/lib.rs
+++ b/projects/collections_exercise/src/lib.rs
@@ -1,4 +1,6 @@
 mod median_mode;
+mod pig_latin;
+
 #[cfg(test)]
 mod median_mode_tests {
     use super::median_mode::median_mode;
@@ -22,3 +24,19 @@ mod median_mode_tests {
     }
 }
 
+#[cfg(test)]
+mod pig_latin_tests {
+    use super::pig_latin::to_pig_latin;
+
+    #[test]
+    fn default_tests() {
+        let test1 = String::from("first");
+        assert_eq!(to_pig_latin(&test1), String::from("irst-fay"));
+
+        let test2 = String::from("apple");
+        assert_eq!(to_pig_latin(&test2), String::from("apple-hay"));
+
+        let test2 = String::from("first apple");
+        assert_eq!(to_pig_latin(&test2), String::from("irst-fay apple-hay"));
+    }
+}

--- a/projects/collections_exercise/src/median_mode.rs
+++ b/projects/collections_exercise/src/median_mode.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+fn median(v: &Vec<i32>) -> f32 {
+    let len = v.len();
+    println!("L: {} l/2 :{}", len, len / 2);
+    let mut sorted_v = v.clone();
+    sorted_v.sort();
+    if len % 2 == 1 {
+        sorted_v[len / 2] as f32
+    } else {
+        let sum = sorted_v[len / 2 - 1] + sorted_v[len / 2];
+        (sum as f32) / 2.0
+    }
+}
+
+fn mode(v: &Vec<i32>) -> i32 {
+    let mut map = HashMap::new();
+
+    for x in v {
+        let count = map.entry(x).or_insert(0);
+        *count += 1;
+    }
+
+    let mut mode = v[0];
+    let mut max_count = 0;
+    for (key, count) in map {
+        if count > max_count {
+            max_count = count;
+            mode = *key;
+        }
+    }
+
+    mode
+}
+
+pub fn median_mode(v: &Vec<i32>) -> (f32, i32) {
+    (median(v), mode(v))
+}

--- a/projects/collections_exercise/src/median_mode.rs
+++ b/projects/collections_exercise/src/median_mode.rs
@@ -1,14 +1,13 @@
 use std::collections::HashMap;
 
 fn median(v: &Vec<i32>) -> f32 {
-    let len = v.len();
-    println!("L: {} l/2 :{}", len, len / 2);
+    let mid = v.len() / 2;
     let mut sorted_v = v.clone();
     sorted_v.sort();
-    if len % 2 == 1 {
-        sorted_v[len / 2] as f32
+    if v.len() % 2 == 1 {
+        sorted_v[mid] as f32
     } else {
-        let sum = sorted_v[len / 2 - 1] + sorted_v[len / 2];
+        let sum = sorted_v[mid - 1] + sorted_v[mid];
         (sum as f32) / 2.0
     }
 }

--- a/projects/collections_exercise/src/median_mode.rs
+++ b/projects/collections_exercise/src/median_mode.rs
@@ -32,6 +32,21 @@ fn mode(v: &Vec<i32>) -> i32 {
     mode
 }
 
+fn mode_v2(v: &Vec<i32>) -> i32 {
+    let mut map = HashMap::new();
+
+    for x in v {
+        let count = map.entry(x).or_insert(0);
+        *count += 1;
+    }
+
+    map.into_iter()
+        .max_by_key(|&(_, count)| count)
+        .map(|(val, _)| val)
+        .copied()
+        .unwrap_or(1)
+}
+
 pub fn median_mode(v: &Vec<i32>) -> (f32, i32) {
     (median(v), mode(v))
 }

--- a/projects/collections_exercise/src/pig_latin.rs
+++ b/projects/collections_exercise/src/pig_latin.rs
@@ -1,0 +1,15 @@
+pub fn to_pig_latin(s: &String) -> String {
+    let mut pig_latin_s = String::new();
+
+    for word in s.split_whitespace() {
+        if word.starts_with(&['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U']) {
+            pig_latin_s.push_str(&format!("{word}-hay "));
+        } else {
+            let first_char = word.chars().next().unwrap_or(' ');
+            let exclude_first_char = &word[1..];
+            pig_latin_s.push_str(&format!("{exclude_first_char}-{first_char}ay "));
+        }
+    }
+
+    pig_latin_s.trim_end().to_string()
+}


### PR DESCRIPTION
1. Given a list of integers, use a vector and return the median (when sorted, the value in the middle position) and mode (the value that occurs most often; a hash map will be helpful here) of the list.
2. Convert strings to pig latin. The first consonant of each word is moved to the end of the word and “ay” is added, so “first” becomes “irst-fay.” Words that start with a vowel have “hay” added to the end instead (“apple” becomes “apple-hay”). Keep in mind the details about UTF-8 encoding!

Did not do the text interface as it seemed redundant for hashmaps and vectors.